### PR TITLE
updated functionality for loading weights

### DIFF
--- a/deltatb/networks/net_segnet.py
+++ b/deltatb/networks/net_segnet.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import torch.utils.model_zoo as model_zoo
+import torch.hub as hub
 __all__ = ["segnet"]
 
 class SegNet(nn.Module):
@@ -152,7 +152,7 @@ class SegNet(nn.Module):
 
     def load_pretrained_weights(self):
 
-        vgg16_weights = model_zoo.load_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
+        vgg16_weights = hub.load_state_dict_from_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
 
         count_vgg = 0
         count_this = 0

--- a/deltatb/networks/net_segnet_bn_relu.py
+++ b/deltatb/networks/net_segnet_bn_relu.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import torch.utils.model_zoo as model_zoo
+import torch.hub as hub
 __all__ = ["segnet_bn_relu"]
 
 class SegNet_BN_ReLU(nn.Module):
@@ -153,7 +153,8 @@ class SegNet_BN_ReLU(nn.Module):
 
     def load_pretrained_weights(self):
 
-        vgg16_weights = model_zoo.load_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
+        vgg16_weights = hub.load_state_dict_from_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
+
 
         count_vgg = 0
         count_this = 0

--- a/deltatb/networks/net_unet.py
+++ b/deltatb/networks/net_unet.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import math
 
-import torch.utils.model_zoo as model_zoo
+import torch.hub as hub
 __all__ = ["unet"]
 
 class Unet(nn.Module):
@@ -160,7 +160,7 @@ class Unet(nn.Module):
 
     def load_pretrained_weights(self):
 
-        vgg16_weights = model_zoo.load_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
+        vgg16_weights = hub.load_state_dict_from_url("https://download.pytorch.org/models/vgg16_bn-6c64b313.pth")
 
         count_vgg = 0
         count_this = 0


### PR DESCRIPTION
the latest version of pytorch says that the functionality of loading pretrained model's weights have been moved to the torch.hub module. Hence, I have made a pull request to update the same in this repository.